### PR TITLE
Possible fix for flex 502s

### DIFF
--- a/src/AppEngineDeploymentTrait.php
+++ b/src/AppEngineDeploymentTrait.php
@@ -96,6 +96,9 @@ trait AppEngineDeploymentTrait
         if (self::$gcloudWrapper->deploy() === false) {
             self::fail('Deployment failed.');
         }
+        if ((int) $delay = getenv('GOOGLE_DEPLOYMENT_DELAY')) {
+            sleep($delay);
+        }
         static::afterDeploy();
     }
 

--- a/src/AppEngineDeploymentTrait.php
+++ b/src/AppEngineDeploymentTrait.php
@@ -109,7 +109,9 @@ trait AppEngineDeploymentTrait
      */
     public static function deleteApp()
     {
-        self::$gcloudWrapper->delete();
+        if (getenv('GOOGLE_KEEP_DEPLOYMENT') !== 'true') {
+            self::$gcloudWrapper->delete();
+        }
     }
 
     /**


### PR DESCRIPTION
This allows us to set `GOOGLE_DEPLOYMENT_DELAY=5` for e2e tests, to fix the `502` failing tests on jenkins until the issue is fixed in App Engine Flex.