### PR TITLE
Removed phpunit:~5.0 from the depenency section

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,6 @@
     "require": {
         "php": ">=5.5",
         "guzzlehttp/guzzle": "~5.3|~6.0",
-        "phpunit/phpunit": "~5.0",
         "symfony/browser-kit": "~2|~3",
         "symfony/console": "~2|~3",
         "symfony/filesystem": "~2|~3",


### PR DESCRIPTION
When I tried to have this tool into a laravel based app, there was a conflict on the phpunit versions. We should not have phpunit on the main dependency section. We still have it in `requrie-dev`.