### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/test/TestUtils/EventuallyConsistentTestTraitTest.php
+++ b/test/TestUtils/EventuallyConsistentTestTraitTest.php
@@ -18,6 +18,7 @@
 namespace Google\Cloud\TestUtils\test;
 
 use Google\Cloud\TestUtils\EventuallyConsistentTestTrait;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class EventuallyConsistentTestTrait
@@ -25,7 +26,7 @@ use Google\Cloud\TestUtils\EventuallyConsistentTestTrait;
  *
  * A class for testing EventuallyConsistentTestTrait.
  */
-class EventuallyConsistentTestTraitTest extends \PHPUnit_Framework_TestCase
+class EventuallyConsistentTestTraitTest extends TestCase
 {
     use EventuallyConsistentTestTrait;
 

--- a/test/TestUtils/GcloudWrapperTest.php
+++ b/test/TestUtils/GcloudWrapperTest.php
@@ -18,6 +18,7 @@
 namespace Google\Cloud\TestUtils\test;
 
 use Google\Cloud\TestUtils\GcloudWrapper;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class GcloudWrapperTest
@@ -25,7 +26,7 @@ use Google\Cloud\TestUtils\GcloudWrapper;
  *
  * A class for testing GcloudWrapper class.
  */
-class GcloudWrapperTest extends \PHPUnit_Framework_TestCase
+class GcloudWrapperTest extends TestCase
 {
     /** @var \Symfony\Component\Process\Process */
     private $mockProcess;

--- a/test/Utils/ContainerExecTest.php
+++ b/test/Utils/ContainerExecTest.php
@@ -21,6 +21,7 @@ use Google\Cloud\Utils\ContainerExec;
 use Google\Cloud\Utils\Gcloud;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Filesystem\Exception\IOExceptionInterface;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class ContainerExecTest
@@ -28,7 +29,7 @@ use Symfony\Component\Filesystem\Exception\IOExceptionInterface;
  *
  * A class for testing ContainerExec class
  */
-class ContainerExecTest extends \PHPUnit_Framework_TestCase
+class ContainerExecTest extends TestCase
 {
     private $gcloud;
     private $fs;

--- a/test/Utils/Flex/FlexExecCommandTest.php
+++ b/test/Utils/Flex/FlexExecCommandTest.php
@@ -22,6 +22,7 @@ use Google\Cloud\Utils\Gcloud;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Filesystem\Exception\IOExceptionInterface;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class FlexExecCommandTest
@@ -29,7 +30,7 @@ use Symfony\Component\Filesystem\Exception\IOExceptionInterface;
  *
  * A class for testing FlexExecCommand class
  */
-class FlexExecCommandTest extends \PHPUnit_Framework_TestCase
+class FlexExecCommandTest extends TestCase
 {
     private $gcloud;
     private $fs;

--- a/test/Utils/GcloudTest.php
+++ b/test/Utils/GcloudTest.php
@@ -18,6 +18,7 @@
 namespace Google\Cloud\Utils\Test;
 
 use Google\Cloud\Utils\Gcloud;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class GcloudTest
@@ -25,7 +26,7 @@ use Google\Cloud\Utils\Gcloud;
  *
  * A class for testing Gcloud class.
  */
-class GcloudTest extends \PHPUnit_Framework_TestCase
+class GcloudTest extends TestCase
 {
     public function setUp()
     {

--- a/test/fixtures/appengine-standard/tests/e2e/DeployTest.php
+++ b/test/fixtures/appengine-standard/tests/e2e/DeployTest.php
@@ -17,8 +17,9 @@
 namespace Google\Cloud\Test;
 
 use Google\Cloud\TestUtils\AppEngineDeploymentTrait;
+use PHPUnit\Framework\TestCase;
 
-class DeployTest extends \PHPUnit_Framework_TestCase
+class DeployTest extends TestCase
 {
     use AppEngineDeploymentTrait;
     use HelloTestTrait;

--- a/test/fixtures/appengine-standard/tests/e2e/LocalTest.php
+++ b/test/fixtures/appengine-standard/tests/e2e/LocalTest.php
@@ -17,8 +17,9 @@
 namespace Google\Cloud\Test;
 
 use Google\Cloud\TestUtils\DevAppserverTestTrait;
+use PHPUnit\Framework\TestCase;
 
-class LocalTest extends \PHPUnit_Framework_TestCase
+class LocalTest extends TestCase
 {
     use DevAppserverTestTrait;
     use HelloTestTrait;


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).