### PR TITLE
Use exponential instead of linear backoff

### DIFF
--- a/src/TestUtils/EventuallyConsistentTestTrait.php
+++ b/src/TestUtils/EventuallyConsistentTestTrait.php
@@ -65,10 +65,10 @@ trait EventuallyConsistentTestTrait
                 return;
             } catch (
                 \PHPUnit\Framework\ExpectationFailedException $testException) {
-                sleep(++$attempts * 2);
+                sleep(pow(2, ++$attempts));
             } catch (\Exception $testException) {
                 if ($catchAllExceptions) {
-                    sleep(++$attempts * 2);
+                    sleep(pow(2, ++$attempts));
                 } else {
                     throw $testException;
                 }


### PR DESCRIPTION
This is a better way to handle backing off, and also it will fix quota limit tests