### PR TITLE
Allows skipping deployment

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
         "twig/twig": "~1.3|~2.0"
     },
     "bin": [
-        "src/Utils/Flex/flex_exec"
+        "src/Utils/Flex/flex_exec",
+        "scripts/install_test_deps.sh"
     ],
     "autoload": {
         "psr-4": {

--- a/src/TestUtils/AppEngineDeploymentTrait.php
+++ b/src/TestUtils/AppEngineDeploymentTrait.php
@@ -27,9 +27,9 @@ use GuzzleHttp\Client;
  */
 trait AppEngineDeploymentTrait
 {
-    /** @var  \Google\Cloud\TestUtils\GcloudWrapper */
+    /** @var \Google\Cloud\TestUtils\GcloudWrapper */
     private static $gcloudWrapper;
-    /** @var  \GuzzleHttp\Client */
+    /** @var \GuzzleHttp\Client */
     private $client;
 
     /**
@@ -70,7 +70,9 @@ trait AppEngineDeploymentTrait
 
     private static function doDeploy()
     {
-        return self::$gcloudWrapper->deploy();
+        if (getenv('GOOGLE_SKIP_DEPLOYMENT') !== 'true') {
+            return self::$gcloudWrapper->deploy();
+        }
     }
 
     /**

--- a/src/TestUtils/GcloudWrapper.php
+++ b/src/TestUtils/GcloudWrapper.php
@@ -183,7 +183,7 @@ class GcloudWrapper
         $this->process->start();
         chdir($orgDir);
         sleep(3);
-        if (! $this->process->isRunning()) {
+        if (!$this->process->isRunning()) {
             $this->errorLog('dev_appserver failed to run.');
             $this->errorLog($this->process->getErrorOutput());
             return false;
@@ -232,7 +232,7 @@ class GcloudWrapper
      */
     public function getLocalBaseUrl()
     {
-        if (! $this->isRunning) {
+        if (!$this->isRunning) {
             $this->errorLog('The app is not running.');
             return false;
         }
@@ -248,9 +248,8 @@ class GcloudWrapper
      */
     public function getBaseUrl($service = 'default')
     {
-        if (! $this->deployed) {
+        if (!$this->deployed) {
             $this->errorLog('The app has not been deployed.');
-            return false;
         }
         if ($service === 'default') {
             $url = sprintf(

--- a/test/TestUtils/GcloudWrapperTest.php
+++ b/test/TestUtils/GcloudWrapperTest.php
@@ -76,8 +76,6 @@ class GcloudWrapperTest extends \PHPUnit_Framework_TestCase
         );
 
         $this->mockGcloudWrapper->delete();
-
-        $this->assertEquals(false, $this->mockGcloudWrapper->getBaseUrl());
     }
 
     public function testDeployAndDeleteWithCustomArgs()
@@ -110,8 +108,6 @@ class GcloudWrapperTest extends \PHPUnit_Framework_TestCase
         );
 
         $this->mockGcloudWrapper->delete('myservice', 4);
-
-        $this->assertEquals(false, $this->mockGcloudWrapper->getBaseUrl());
     }
 
     public function testRunAndStopWithDefault()


### PR DESCRIPTION
- Allows for deployments to be skipped in deployment tests by setting `GOOGLE_SKIP_DEPLOYMENT=true`
- Allows `install_test_deps.sh` to be run using `vendor/bin/intall_test_deps.sh`
- Cleans up CS