### PR TITLE
Add Deadline-based exponential backoff

### DIFF
--- a/src/Utils/DeadlineExponentialBackoff.php
+++ b/src/Utils/DeadlineExponentialBackoff.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Utils;
+
+/**
+ * Exponential backoff implementation based off timeout instead of retries.
+ * @internal
+ */
+class DeadlineExponentialBackoff extends ExponentialBackoff
+{
+    const TIMEOUT_SECONDS_DEFAULT = 60; // one minute
+
+    /**
+     * @var float
+     */
+    private $deadlineMicros;
+
+    /**
+     * @param float $deadlineMicros [optional] Duration from first execution to retry in seconds.
+     * @param callable $retryFunction [optional] returns bool for whether or not to retry.
+     */
+    public function __construct($deadlineMicros = null, callable $retryFunction = null)
+    {
+        if (is_null($deadlineMicros)) {
+            $deadlineMicros = microtime(true) + self::TIMEOUT_SECONDS_DEFAULT;
+        }
+        $this->deadlineMicros = $deadlineMicros;
+
+        // Call retry backoff with -1 for infinite retry count.
+        parent::__construct(-1, $retryFunction);
+    }
+
+    /**
+     * Function which returns bool for whether or not to retry.
+     *
+     * @param Exception $exception
+     * @return bool
+     */
+    protected function shouldRetry(\Exception $exception)
+    {
+        // Retry forever when $deadlineMicros is -1
+        if (-1 === $this->deadlineMicros || $this->deadlineMicros > microtime(true)){
+            if (parent::shouldRetry($exception)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Utils/ExponentialBackoff.php
+++ b/src/Utils/ExponentialBackoff.php
@@ -120,7 +120,8 @@ class ExponentialBackoff
      */
     protected function shouldRetry(\Exception $exception)
     {
-        if ($this->retryAttempt < $this->retries) {
+        // Always retry when retries is -1
+        if (-1 === $this->retries || $this->retryAttempt < $this->retries) {
             if (!$this->retryFunction) {
                 $this->retryAttempt++;
                 return true;

--- a/test/Utils/DeadlineExponentialBackoffTest.php
+++ b/test/Utils/DeadlineExponentialBackoffTest.php
@@ -52,7 +52,7 @@ class DeadlineExponentialBackoffTest extends TestCase
      */
     public function testNoRetryFunc()
     {
-        $neverRetryFunc = function() {
+        $neverRetryFunc = function () {
             return false;
         };
         $actualAttempts = 0;

--- a/test/Utils/DeadlineExponentialBackoffTest.php
+++ b/test/Utils/DeadlineExponentialBackoffTest.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Utils\Test;
+
+use Google\Cloud\Utils\DeadlineExponentialBackoff;
+use PHPUnit\Framework\TestCase;
+
+class DeadlineExponentialBackoffTest extends TestCase
+{
+    private $delayFunction;
+
+    public function setUp()
+    {
+        $this->delayFunction = function () {
+            return;
+        };
+    }
+
+    public function testInfiniteRetriesDeadline()
+    {
+        $actualAttempts = 0;
+        $backoff = new DeadlineExponentialBackoff(-1);
+        $backoff->setDelayFunction($this->delayFunction);
+        $backoff->execute(function () use (&$actualAttempts) {
+            if ($actualAttempts < 1000) {
+                $actualAttempts++;
+                throw new \Exception('Intentional exception');
+            }
+        });
+
+        $this->assertEquals(1000, $actualAttempts);
+    }
+
+    /**
+     * @expectedException Exception
+     * @expectedExceptionMessage Intentional exception
+     */
+    public function testNoRetryFunc()
+    {
+        $neverRetryFunc = function() {
+            return false;
+        };
+        $actualAttempts = 0;
+        $backoff = new DeadlineExponentialBackoff(-1, $neverRetryFunc);
+        $backoff->setDelayFunction($this->delayFunction);
+        $backoff->execute(function () use (&$actualAttempts) {
+            $actualAttempts++;
+            throw new \Exception('Intentional exception');
+        });
+    }
+
+    public function testTwoSecondDeadlineFunction()
+    {
+        $timeNow = microtime(true);
+        $actualAttempts = 0;
+        $backoff = new DeadlineExponentialBackoff($timeNow + 2);
+        $backoff->setDelayFunction($this->delayFunction);
+        try {
+            $backoff->execute(function () use (&$actualAttempts) {
+                $actualAttempts++;
+                throw new \Exception('Intentional exception');
+            });
+        } catch (\Exception $e) {
+            if ($e->getMessage() !== 'Intentional exception') {
+                throw $e;
+            }
+        }
+
+        $this->assertGreaterThan(1, $actualAttempts);
+        $this->assertGreaterThan($timeNow + 2, microtime(true));
+        $this->assertGreaterThan(microtime(true), $timeNow + 3);
+    }
+}


### PR DESCRIPTION
Enforcing timestamp-based backoff.

Another possibility would be to make the first argument to [ExponentialBackoff](https://github.com/GoogleCloudPlatform/php-tools/blob/master/src/Utils/ExponentialBackoff.php) be an optional `float`, in which case it becomes a deadline instead of a retry count.

It's a hack, but it may be better than this...
