### PR TITLE
Adds retry trait for retry annotations

### DIFF
--- a/src/TestUtils/RetryTrait.php
+++ b/src/TestUtils/RetryTrait.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\TestUtils;
+
+use LogicException;
+use PHPUnit\Framework\IncompleteTestError;
+use PHPUnit\Framework\SkippedTestError;
+use Throwable;
+use Exception;
+use Error;
+
+/**
+ * Trait for adding a @retry annotation to retry flakey tests.
+ *
+ * @see https://blog.forma-pro.com/retry-an-erratic-test-fc4d928c57fb
+ */
+trait RetryTrait
+{
+    public function runBare()
+    {
+        $e = null;
+        $retries = $this->getNumberOfRetries();
+        for ($i = 0; $i < $retries; ++$i) {
+            if ($i > 0) {
+                printf('[RETRY] Attempt %s of %s' . PHP_EOL,
+                    $i + 1,
+                    $retries);
+            }
+            try {
+                return parent::runBare();
+            } catch (IncompleteTestError $e) {
+                throw $e;
+            } catch (SkippedTestError $e) {
+                throw $e;
+            } catch (Throwable $e) {
+            } catch (Exception $e) {
+            } catch (Error $e) {
+            }
+        }
+        if ($e) {
+            throw $e;
+        }
+    }
+
+    /**
+     * @return int
+     */
+    private function getNumberOfRetries()
+    {
+        $annotations = $this->getAnnotations();
+        $retries = 1;
+
+        if (isset($annotations['class']['retry'][0])) {
+            $retries = $annotations['class']['retry'][0];
+        }
+        if (isset($annotations['method']['retry'][0])) {
+            $retries = $annotations['method']['retry'][0];
+        }
+
+        return $this->validateRetries($retries);
+    }
+
+    private function validateRetries($retries)
+    {
+        if ('' === $retries) {
+            throw new LogicException(
+                'The @retry annotation requires a positive integer as an argument'
+            );
+        }
+        if (false === is_numeric($retries)) {
+            throw new LogicException(sprintf(
+                'The @retry annotation must be an integer but got "%s"',
+                var_export($retries, true)
+            ));
+        }
+        if (floatval($retries) != intval($retries)) {
+            throw new LogicException(sprintf(
+                'The @retry annotation must be an integer but got "%s"',
+                floatval($retries)
+            ));
+        }
+        $retries = (int) $retries;
+        if ($retries <= 0) {
+            throw new LogicException(sprintf(
+                'The $retries must be greater than 0 but got "%s".',
+                $retries
+            ));
+        }
+        return $retries;
+    }
+}

--- a/test/TestUtils/RetryTraitTest.php
+++ b/test/TestUtils/RetryTraitTest.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * Copyright 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\TestUtils\test;
+
+use Google\Cloud\TestUtils\RetryTrait;
+use Exception;
+
+/**
+ * Class RetryTraitTest
+ * @package Google\Cloud\TestUtils\Test
+ *
+ * A class for testing RetryTrait.
+ *
+ * @retry 2
+ */
+class RetryTraitTest extends \PHPUnit_Framework_TestCase
+{
+    use RetryTrait;
+
+    private static $timesCalled = 0;
+
+    public function testClassRetries()
+    {
+        $this->assertEquals(2, $this->getNumberOfRetries());
+    }
+
+    /**
+     * @retry 3
+     */
+    public function testMethodRetries()
+    {
+        $this->assertEquals(3, $this->getNumberOfRetries());
+    }
+
+    /**
+     * @expectedException LogicException
+     * @expectedExceptionMessage The @retry annotation requires a positive integer as an argument
+     */
+    public function testNoArgumentToRetryAnnotation()
+    {
+        $this->validateRetries('');
+    }
+
+    /**
+     * @expectedException LogicException
+     * @expectedExceptionMessage The @retry annotation must be an integer but got "'foo'"
+     */
+    public function testInvalidStringArgumentTypeToRetryAnnotation()
+    {
+        $this->validateRetries('foo');
+    }
+
+    /**
+     * @expectedException LogicException
+     * @expectedExceptionMessage The @retry annotation must be an integer but got "1.2"
+     */
+    public function testInvalidFloatArgumentTypeToRetryAnnotation()
+    {
+        $this->validateRetries('1.2');
+    }
+
+    /**
+     * @expectedException LogicException
+     * @expectedExceptionMessage The $retries must be greater than 0 but got "0"
+     */
+    public function testNonPositiveIntegerToRetryAnnotation()
+    {
+        $this->validateRetries(0);
+    }
+
+    public function testValidRetryAnnotations()
+    {
+        $this->assertEquals(1, $this->validateRetries(1));
+        $this->assertEquals(1, $this->validateRetries('1'));
+        $this->assertEquals(1, $this->validateRetries(1.0));
+        $this->assertEquals(1, $this->validateRetries('1.0'));
+    }
+
+    /**
+     * @retry 3
+     */
+    public function testRetriesOnException()
+    {
+        self::$timesCalled++;
+        $numRetries = $this->getNumberOfRetries();
+        if (self::$timesCalled < $numRetries) {
+            throw new Exception('Intentional Exception');
+        }
+        $this->assertEquals($numRetries, self::$timesCalled);
+    }
+}


### PR DESCRIPTION
Annotations for retrying a method or class tests:

```php
/**
 * @retry 2
 */
class MyTest extends PHPUnit\Framework\TestCase
{
    use Google\Cloud\TestUtils\RetryTrait;

    public function testSomethingFlakeyTwice()
    {
        // test something flakey
    }
    
    /**
     * @retry 3
     */
    public function testSomethingFlakeyThreeTimes()
    {
        // test something flakey
    }
}
```

We could potentially add support for sleeping and ExponentialBackoff as well (with the option to override `retryBackoffDelayFunction` in the test class), e.g.

```php
/**
 * @retry 3
 * @retryBackoff
 */
```

Or with sleep:

```php
/**
 * @retry 3
 * @retrySleepSeconds 10
 */
``` 

And in the spirit of https://github.com/GoogleCloudPlatform/php-tools/pull/70, we could add a deadline

```php
/**
 * @retry 3
 * @retryDeadlineSeconds 60
 */
``` 

cc @dwsupplee