### PR TITLE
fix(cloudbuild): Adapt syntax to implementation

### DIFF
--- a/src/Utils/ContainerExec.php
+++ b/src/Utils/ContainerExec.php
@@ -93,7 +93,6 @@ class ContainerExec
         file_put_contents("$this->workdir/cloudbuild.yaml", $cloudBuildYaml);
         list($result, $cmdOutput) = $this->gcloud->exec(
             [
-                'container',
                 'builds',
                 'submit',
                 "--config=$this->workdir/cloudbuild.yaml",

--- a/test/Utils/ContainerExecTest.php
+++ b/test/Utils/ContainerExecTest.php
@@ -92,7 +92,6 @@ class ContainerExecTest extends \PHPUnit_Framework_TestCase
         $image = 'gcr.io/my-project/my-image';
         $this->gcloud->exec(
             [
-                'container',
                 'builds',
                 'submit',
                 "--config=$this->workdir/cloudbuild.yaml",

--- a/test/Utils/Flex/FlexExecCommandTest.php
+++ b/test/Utils/Flex/FlexExecCommandTest.php
@@ -101,7 +101,6 @@ class FlexExecCommandTest extends \PHPUnit_Framework_TestCase
             );
         $this->gcloud->exec(
             [
-                'container',
                 'builds',
                 'submit',
                 "--config=$this->workdir/cloudbuild.yaml",


### PR DESCRIPTION
Outdated:

`gcloud container builds submit`

Current

`gcloud builds submit`

