### PR TITLE
Add support for Guzzle 7.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "php": ">=5.5",
-        "guzzlehttp/guzzle": "~5.3 || ~6.0",
+        "guzzlehttp/guzzle": "~5.3 || ~6.0 || ~7.0",
         "symfony/browser-kit": "^3.4 || ^4.3 || ^5.0",
         "symfony/console": "^3.4 || ^4.3 || ^5.0",
         "symfony/filesystem": "^3.4 || ^4.3 || ^5.0",


### PR DESCRIPTION
Greetings 👋,

[Guzzle 7.0 has just been released](https://github.com/guzzle/guzzle/releases), this change widens the version constraint so that it can be used here and in other Google PHP libraries using the PHP Tools.

A new client is instantiated in [TestUtils/DeploymentTrait.php](https://github.com/GoogleCloudPlatform/php-tools/blob/master/src/TestUtils/DeploymentTrait.php) and in [TestUtils/DevAppserverTestTrait.php](https://github.com/GoogleCloudPlatform/php-tools/blob/master/src/TestUtils/DevAppserverTestTrait.php) - since the `base_uri` client config parameter hasn't changed, this should continue working as before.

:octocat: 