### PR TITLE
Allow the twig 3.0 series

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "symfony/console": "^3.4 || ^4.3 || ^5.0",
         "symfony/filesystem": "^3.4 || ^4.3 || ^5.0",
         "symfony/process": "^3.4 || ^4.3 || ^5.0",
-        "twig/twig": "~1.3 || ~2.0"
+        "twig/twig": "~1.3 || ~2.0 || ~3.0"
     },
     "bin": [
         "src/Utils/Flex/flex_exec",


### PR DESCRIPTION
The `symfony/*` bundles mostly allow the use of `v3.0.*` So making this compatible should solve allot of composer locking issues