### PR TITLE
fix: remove deprecated app-engine-php component

### DIFF
--- a/scripts/install_test_deps.sh
+++ b/scripts/install_test_deps.sh
@@ -48,7 +48,6 @@ configure_gcloud()
             "${GOOGLE_APPLICATION_CREDENTIALS}"
     fi
     gcloud -q components install app-engine-python
-    gcloud -q components install app-engine-php
     gcloud -q components update
     if [ -n "${GCLOUD_VERBOSITY}" ]; then
         gcloud -q config set verbosity ${GCLOUD_VERBOSITY}


### PR DESCRIPTION
`gcloud` has removed the component `app-engine-php`. We must remove the installation of this component so the gcloud install script can succeed