### PR TITLE
feat(functions): add testing support for Functions

### DIFF
--- a/src/TestUtils/CloudFunctionDeploymentTrait.php
+++ b/src/TestUtils/CloudFunctionDeploymentTrait.php
@@ -40,7 +40,7 @@ trait CloudFunctionDeploymentTrait
     {
         $projectId = self::requireEnv('GOOGLE_PROJECT_ID');
         $versionId = self::requireEnv('GOOGLE_VERSION_ID');
-        self::$fn = new CloudFunction($projectId, self::$name, ['functionName' => self::$name.'-'.$versionId]);
+        self::$fn = new CloudFunction($projectId, self::$name, ['functionName' => self::$name . '-' . $versionId]);
     }
 
     /**

--- a/src/TestUtils/CloudFunctionDeploymentTrait.php
+++ b/src/TestUtils/CloudFunctionDeploymentTrait.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\TestUtils;
+
+use Google\Auth\ApplicationDefaultCredentials;
+use Google\Cloud\TestUtils\GcloudWrapper\CloudFunction;
+use GuzzleHttp\Client;
+use GuzzleHttp\HandlerStack;
+
+/**
+ * Trait CloudFunctionDeploymentTrait.
+ */
+trait CloudFunctionDeploymentTrait
+{
+    use TestTrait;
+    use DeploymentTrait;
+
+    /** @var \Google\Cloud\TestUtils\GcloudWrapper\CloudFunction */
+    private static $fn;
+
+    /**
+     * Prepare the Cloud Function.
+     */
+    public static function setUpDeploymentVars()
+    {
+        $projectId = self::requireEnv('GOOGLE_PROJECT_ID');
+        $versionId = self::requireEnv('GOOGLE_VERSION_ID');
+        self::$fn = new CloudFunction($projectId, self::$name, ['functionName' => self::$name.'-'.$versionId]);
+    }
+
+    /**
+     * Prepare to deploy app, called from DeploymentTrait::deployApp().
+     */
+    private static function beforeDeploy()
+    {
+        // Ensure setUpDeploymentVars has been called
+        if (is_null(self::$fn)) {
+            self::setUpDeploymentVars();
+        }
+
+        // Suppress gcloud prompts during deployment.
+        putenv('CLOUDSDK_CORE_DISABLE_PROMPTS=1');
+    }
+
+    /**
+     * Deploy the Cloud Function.
+     */
+    private static function doDeploy()
+    {
+        if (false === self::$fn->deploy()) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Delete a deployed Cloud Function.
+     */
+    private static function doDelete()
+    {
+        self::$fn->delete();
+    }
+
+    /**
+     * Set up the client.
+     *
+     * @before
+     */
+    public function setUpClient()
+    {
+        $targetAudience = self::getBaseUri();
+
+        // Create middleware.
+        $middleware = ApplicationDefaultCredentials::getIdTokenMiddleware($targetAudience);
+        $stack = HandlerStack::create();
+        $stack->push($middleware);
+
+        // Create the HTTP client.
+        $this->client = new Client([
+            'handler' => $stack,
+            'auth' => 'google_auth',
+            'base_uri' => $targetAudience,
+        ]);
+    }
+
+    public function getBaseUri()
+    {
+        return self::$fn->getBaseUrl();
+    }
+}

--- a/src/TestUtils/GcloudWrapper/AppEngine.php
+++ b/src/TestUtils/GcloudWrapper/AppEngine.php
@@ -95,12 +95,13 @@ class AppEngine
         }
         $orgDir = getcwd();
         if (chdir($this->dir) === false) {
-            $this->errorLog('Can not chdir to '.$this->dir);
+            $this->errorLog('Can not chdir to ' . $this->dir);
 
             return false;
         }
-        $cmd = sprintf('gcloud -q %s%s deploy --project %s --version %s %s %s',
-            $options['release_version'] ? $options['release_version'].' ' : '',
+        $cmd = sprintf(
+            'gcloud -q %s%s deploy --project %s --version %s %s %s',
+            $options['release_version'] ? $options['release_version'] . ' ' : '',
             self::GCLOUD_COMPONENT,
             $this->project,
             $this->version,
@@ -128,13 +129,13 @@ class AppEngine
         $targets = 'app.yaml',
         $phpCgiPath = '/usr/bin/php-cgi'
     ) {
-        $cmd = 'dev_appserver.py --port '.$this->port
-            .' --skip_sdk_update_check true'
-            .' --php_executable_path '.$phpCgiPath
-            .' '.$targets;
+        $cmd = 'dev_appserver.py --port ' . $this->port
+            . ' --skip_sdk_update_check true'
+            . ' --php_executable_path ' . $phpCgiPath
+            . ' ' . $targets;
         $orgDir = getcwd();
         if (chdir($this->dir) === false) {
-            $this->errorLog('Can not chdir to '.$this->dir);
+            $this->errorLog('Can not chdir to ' . $this->dir);
 
             return false;
         }
@@ -176,9 +177,9 @@ class AppEngine
         $service = 'default',
         $retries = 3
     ) {
-        $cmd = 'gcloud -q '.self::GCLOUD_COMPONENT.' versions delete '
-            .'--service '.$service.' '
-            .$this->version.' --project '.$this->project;
+        $cmd = 'gcloud -q ' . self::GCLOUD_COMPONENT . ' versions delete '
+            . '--service ' . $service . ' '
+            . $this->version . ' --project ' . $this->project;
         $ret = $this->execWithRetry($cmd, $retries);
         if ($ret) {
             $this->deployed = false;
@@ -201,7 +202,7 @@ class AppEngine
             return false;
         }
 
-        return 'http://127.0.0.1:'.$this->port;
+        return 'http://127.0.0.1:' . $this->port;
     }
 
     /**

--- a/src/TestUtils/GcloudWrapper/AppEngine.php
+++ b/src/TestUtils/GcloudWrapper/AppEngine.php
@@ -18,10 +18,7 @@
 namespace Google\Cloud\TestUtils\GcloudWrapper;
 
 /**
- * Class GcloudWrapper
- * @package Google\Cloud\TestUtils
- *
- * A class representing App Engine application.
+ * Class AppEngine.
  */
 class AppEngine
 {
@@ -33,16 +30,16 @@ class AppEngine
     /** @var string */
     private $port;
 
-    const GCLOUD_APP = 'app';
+    const GCLOUD_COMPONENT = 'app';
     const DEFAULT_PORT = 8080;
 
     /**
-     * Constructor of GcloudWrapper.
+     * Constructor of AppEngine.
      *
-     * @param string $project
-     * @param string $version
-     * @param string|null $dir optional
-     * @param int $port optional
+     * @param string      $project
+     * @param string      $version
+     * @param string|null $dir     optional
+     * @param int         $port    optional
      */
     public function __construct(
         $project,
@@ -62,11 +59,12 @@ class AppEngine
      * Deploy the app to the Google Cloud Platform using App Engine.
      *
      * @param array $options list of options
-     *      $targets string The yaml files for deployments.
-     *      $promote bool True if you want to promote the new app.
-     *      $retries int Number of retries upon failure.
-     *      $release_version string Run using "alpha" or "beta" version of gcloud deploy
-     * @return bool true if deployment suceeds, false upon failure.
+     *                       $targets string The yaml files for deployments.
+     *                       $promote bool True if you want to promote the new app.
+     *                       $retries int Number of retries upon failure.
+     *                       $release_version string Run using "alpha" or "beta" version of gcloud deploy
+     *
+     * @return bool true if deployment suceeds, false upon failure
      */
     public function deploy($options = [])
     {
@@ -87,20 +85,23 @@ class AppEngine
         ], $options);
         if (!in_array($options['release_version'], [null, 'alpha', 'beta'])) {
             $this->errorLog('release_version must be "alpha" or "beta"');
+
             return false;
         }
         if ($this->deployed) {
             $this->errorLog('The app has been already deployed.');
+
             return false;
         }
         $orgDir = getcwd();
         if (chdir($this->dir) === false) {
-            $this->errorLog('Can not chdir to ' . $this->dir);
+            $this->errorLog('Can not chdir to '.$this->dir);
+
             return false;
         }
         $cmd = sprintf('gcloud -q %s%s deploy --project %s --version %s %s %s',
-            $options['release_version'] ? $options['release_version'] . ' ' : '',
-            self::GCLOUD_APP,
+            $options['release_version'] ? $options['release_version'].' ' : '',
+            self::GCLOUD_COMPONENT,
             $this->project,
             $this->version,
             $options['promote'] ? '--promote' : '--no-promote',
@@ -111,27 +112,30 @@ class AppEngine
         if ($ret) {
             $this->deployed = true;
         }
+
         return $ret;
     }
 
     /**
      * Run the app with dev_appserver.
      *
-     * @param string $targets optional The yaml files for local run.
-     * @param string $phpCgiPath optional The path to php-cgi.
-     * @return bool true if the app is running, otherwise false.
+     * @param string $targets    optional The yaml files for local run
+     * @param string $phpCgiPath optional The path to php-cgi
+     *
+     * @return bool true if the app is running, otherwise false
      */
     public function run(
         $targets = 'app.yaml',
         $phpCgiPath = '/usr/bin/php-cgi'
     ) {
-        $cmd = 'dev_appserver.py --port ' . $this->port
-            . ' --skip_sdk_update_check true'
-            . ' --php_executable_path ' . $phpCgiPath
-            . ' ' . $targets;
+        $cmd = 'dev_appserver.py --port '.$this->port
+            .' --skip_sdk_update_check true'
+            .' --php_executable_path '.$phpCgiPath
+            .' '.$targets;
         $orgDir = getcwd();
         if (chdir($this->dir) === false) {
-            $this->errorLog('Can not chdir to ' . $this->dir);
+            $this->errorLog('Can not chdir to '.$this->dir);
+
             return false;
         }
         $this->process = $this->createProcess($cmd);
@@ -141,9 +145,11 @@ class AppEngine
         if (!$this->process->isRunning()) {
             $this->errorLog('dev_appserver failed to run.');
             $this->errorLog($this->process->getErrorOutput());
+
             return false;
         }
         $this->isRunning = true;
+
         return true;
     }
 
@@ -162,20 +168,22 @@ class AppEngine
      * Delete the deployed app.
      *
      * @param string $service
-     * @param int $retries optional The number of retries upon failure.
+     * @param int    $retries optional The number of retries upon failure
+     *
      * @return bool true if the app is succesfully deleted, otherwise false
      */
     public function delete(
         $service = 'default',
         $retries = 3
     ) {
-        $cmd = "gcloud -q " . self::GCLOUD_APP . " versions delete "
-            . "--service " . $service . " "
-            . $this->version . " --project " . $this->project;
+        $cmd = 'gcloud -q '.self::GCLOUD_COMPONENT.' versions delete '
+            .'--service '.$service.' '
+            .$this->version.' --project '.$this->project;
         $ret = $this->execWithRetry($cmd, $retries);
         if ($ret) {
             $this->deployed = false;
         }
+
         return $ret;
     }
 
@@ -183,23 +191,26 @@ class AppEngine
      * Return the base URL of the local dev_appserver.
      *
      * @return mixed returns the base URL of the running app, or false when
-     *     the app is not running
+     *               the app is not running
      */
     public function getLocalBaseUrl()
     {
         if (!$this->isRunning) {
             $this->errorLog('The app is not running.');
+
             return false;
         }
-        return 'http://127.0.0.1:' . $this->port;
+
+        return 'http://127.0.0.1:'.$this->port;
     }
 
     /**
      * Return the base URL of the deployed app.
      *
      * @param string $service optional
+     *
      * @return mixed returns the base URL of the deployed app, or false when
-     *     the app is not deployed.
+     *               the app is not deployed
      */
     public function getBaseUrl($service = 'default')
     {
@@ -220,6 +231,7 @@ class AppEngine
                 $this->project
             );
         }
+
         return $url;
     }
 }

--- a/src/TestUtils/GcloudWrapper/CloudFunction.php
+++ b/src/TestUtils/GcloudWrapper/CloudFunction.php
@@ -1,0 +1,260 @@
+<?php
+/**
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\TestUtils\GcloudWrapper;
+
+/**
+ * Class CloudFunction.
+ */
+class CloudFunction
+{
+    use GcloudWrapperTrait;
+
+    /** @var string */
+    private $functionName;
+
+    /** @var string */
+    private $entryPoint;
+
+    /** @var string */
+    private $region;
+
+    /** @var string */
+    private $runtime;
+
+    /** @var string */
+    private $trigger;
+
+    /** @var string */
+    private $url;
+
+    /** @var string */
+    private $port;
+
+    const GCLOUD_COMPONENT = 'functions';
+    const DEFAULT_REGION = 'us-central1';
+    const DEFAULT_RUNTIME = 'php74';
+    const DEFAULT_TRIGGER = '--trigger-http';
+    const DEFAULT_PORT = '8080';
+
+    /**
+     * Constructor of CloudFunction.
+     *
+     * @param string $project
+     */
+    public function __construct(
+        $project,
+        $entryPoint,
+        array $options = []
+    ) {
+        $options = array_merge([
+            'functionName' => $entryPoint,
+            'region' => self::DEFAULT_REGION,
+            'runtime' => self::DEFAULT_RUNTIME,
+            'trigger' => self::DEFAULT_TRIGGER,
+            'port' => self::DEFAULT_PORT,
+            'dir' => null,
+        ], $options);
+
+        $this->project = $project;
+        $this->entryPoint = $entryPoint;
+
+        foreach ($options as $name => $value) {
+            $this->$name = $value;
+        }
+
+        $this->setDefaultVars($project, $options['dir']);
+    }
+
+    /**
+     * Deploy the app to the Google Cloud Platform using App Engine.
+     *
+     * @param array $options list of options
+     *                       $retries int Number of retries upon failure.
+     *                       $release_version string Run using "alpha" or "beta" version of gcloud deploy
+     *
+     * @return bool true if deployment suceeds, false upon failure
+     */
+    public function deploy($options = [])
+    {
+        if ($this->deployed) {
+            $this->errorLog('The function has already been deployed.');
+
+            // If we've already deployed, assume the function is ready for use.
+            return true;
+        }
+        // Handle old function signature
+        if (!is_array($options)) {
+            $options = array_filter([
+                'retries' => @func_get_arg(1),
+            ], 'is_numeric');
+        }
+        $options = array_merge([
+            'retries' => 3,
+            'release_version' => null,
+        ], $options);
+        if (!in_array($options['release_version'], [null, 'alpha', 'beta'])) {
+            $this->errorLog('release_version must be "alpha" or "beta"');
+
+            return false;
+        }
+        $orgDir = getcwd();
+        if (chdir($this->dir) === false) {
+            $this->errorLog('Can not chdir to '.$this->dir);
+
+            return false;
+        }
+        $cmd = sprintf('gcloud -q %s%s deploy %s --entry-point %s --runtime %s --project %s --region %s %s --no-allow-unauthenticated',
+            $options['release_version'] ? $options['release_version'].' ' : '',
+            self::GCLOUD_COMPONENT,
+            $this->functionName,
+            $this->entryPoint,
+            $this->runtime,
+            $this->project,
+            $this->region,
+            $this->trigger,
+        );
+        $ret = $this->execWithRetry($cmd, $options['retries']);
+        chdir($orgDir);
+        if ($ret) {
+            $this->deployed = true;
+        }
+
+        return $ret;
+    }
+
+    /**
+     * Run the function with the php development server.
+     *
+     * @return bool true if the app is running, otherwise false
+     */
+    public function run($phpBin = 'php')
+    {
+        $type = $this->isCloudEventFunction() ? 'FUNCTION_SIGNATURE_TYPE=cloudevent' : '';
+        $cmd = $type.'FUNCTION_TARGET='.$this->functionName.' '.$phpBin.' -S localhost:'.$this->port.' vendor/bin/router.php';
+        $orgDir = getcwd();
+        if (chdir($this->dir) === false) {
+            $this->errorLog('Can not chdir to '.$this->dir);
+
+            return false;
+        }
+        $this->process = $this->createProcess($cmd);
+        $this->process->start();
+        chdir($orgDir);
+        sleep(3);
+        if (!$this->process->isRunning()) {
+            $this->errorLog('php server failed to run.');
+            $this->errorLog($this->process->getErrorOutput());
+
+            return false;
+        }
+        $this->isRunning = true;
+
+        return true;
+    }
+
+    /**
+     * Stop the php development server.
+     */
+    public function stop()
+    {
+        if ($this->process->isRunning()) {
+            $this->process->stop();
+        }
+        $this->isRunning = false;
+    }
+
+    /**
+     * Delete the deployed function.
+     *
+     * @param int $retries optional The number of retries upon failure
+     *
+     * @return bool true if the function is succesfully deleted, otherwise false
+     */
+    public function delete($retries = 3)
+    {
+        if (!$this->deployed) {
+            $this->errorLog('Nothing to delete: function not deployed.');
+
+            return false;
+        }
+
+        $cmd = 'gcloud -q '.self::GCLOUD_COMPONENT.' delete '
+            .$this->functionName.' --project '.$this->project.' --region '.$this->region;
+        $ret = $this->execWithRetry($cmd, $retries);
+        if ($ret) {
+            $this->deployed = false;
+        }
+
+        return $ret;
+    }
+
+    /**
+     * Return the base URL of the local dev_appserver.
+     *
+     * @return mixed returns the base URL of the running app, or false when
+     *               the app is not running
+     */
+    public function getLocalBaseUrl()
+    {
+        if (!$this->isRunning) {
+            $this->errorLog('The function is not running.');
+
+            return false;
+        }
+
+        return 'http://localhost:'.$this->port;
+    }
+
+    /**
+     * Return the base URL of the deployed function.
+     *
+     * @return mixed returns the base URL of the deployed function, or false when
+     *               the function is not deployed or not HTTP triggered
+     */
+    public function getBaseUrl($retries = 3)
+    {
+        if (!$this->deployed) {
+            echo '$this->deployed is empty by the time getBaseUrl is called.'.PHP_EOL;
+            $this->errorLog('The function has not been deployed.');
+
+            return false;
+        }
+
+        if ($this->isCloudEventFunction()) {
+            $this->errorLog('The function is deployed as a CloudEvent Function.');
+
+            return false;
+        }
+
+        if (empty($this->url)) {
+            $cmd = 'gcloud -q '.self::GCLOUD_COMPONENT.' describe '.$this->functionName
+            .' --format \'value(httpsTrigger.url)\' --project '.$this->project.' --region '.$this->region;
+            $this->url = $this->execWithRetry($cmd, $retries, $url);
+            $this->url = $url[0];
+        }
+
+        return $this->url;
+    }
+
+    // Returns true if the function is a CloudEvent function.
+    private function isCloudEventFunction()
+    {
+        // Default trigger is an http trigger. If that's not in use, assume an event trigger.
+        return  $this->trigger != self::DEFAULT_TRIGGER;
+    }
+}

--- a/src/TestUtils/GcloudWrapper/CloudFunction.php
+++ b/src/TestUtils/GcloudWrapper/CloudFunction.php
@@ -145,15 +145,17 @@ class CloudFunction
      */
     public function run($phpBin = 'php')
     {
-        $type = $this->isCloudEventFunction() ? 'FUNCTION_SIGNATURE_TYPE=cloudevent' : '';
-        $cmd = $type . 'FUNCTION_TARGET=' . $this->functionName . ' ' . $phpBin . ' -S localhost:' . $this->port . ' vendor/bin/router.php';
+        $cmd = $phpBin . ' -S localhost:' . $this->port . ' vendor/bin/router.php';
         $orgDir = getcwd();
         if (chdir($this->dir) === false) {
             $this->errorLog('Can not chdir to ' . $this->dir);
 
             return false;
         }
-        $this->process = $this->createProcess($cmd);
+        $this->process = $this->createProcess($cmd, [
+            'FUNCTION_TARGET' => $this->functionName,
+            'FUNCTION_SIGNATURE_TYPE' => $this->isCloudEventFunction() ? 'cloudevent' : 'http',
+        ]);
         $this->process->start();
         chdir($orgDir);
         sleep(3);

--- a/src/TestUtils/GcloudWrapper/CloudFunction.php
+++ b/src/TestUtils/GcloudWrapper/CloudFunction.php
@@ -114,12 +114,13 @@ class CloudFunction
         }
         $orgDir = getcwd();
         if (chdir($this->dir) === false) {
-            $this->errorLog('Can not chdir to '.$this->dir);
+            $this->errorLog('Can not chdir to ' . $this->dir);
 
             return false;
         }
-        $cmd = sprintf('gcloud -q %s%s deploy %s --entry-point %s --runtime %s --project %s --region %s %s --no-allow-unauthenticated',
-            $options['release_version'] ? $options['release_version'].' ' : '',
+        $cmd = sprintf(
+            'gcloud -q %s%s deploy %s --entry-point %s --runtime %s --project %s --region %s %s --no-allow-unauthenticated',
+            $options['release_version'] ? $options['release_version'] . ' ' : '',
             self::GCLOUD_COMPONENT,
             $this->functionName,
             $this->entryPoint,
@@ -145,10 +146,10 @@ class CloudFunction
     public function run($phpBin = 'php')
     {
         $type = $this->isCloudEventFunction() ? 'FUNCTION_SIGNATURE_TYPE=cloudevent' : '';
-        $cmd = $type.'FUNCTION_TARGET='.$this->functionName.' '.$phpBin.' -S localhost:'.$this->port.' vendor/bin/router.php';
+        $cmd = $type . 'FUNCTION_TARGET=' . $this->functionName . ' ' . $phpBin . ' -S localhost:' . $this->port . ' vendor/bin/router.php';
         $orgDir = getcwd();
         if (chdir($this->dir) === false) {
-            $this->errorLog('Can not chdir to '.$this->dir);
+            $this->errorLog('Can not chdir to ' . $this->dir);
 
             return false;
         }
@@ -193,8 +194,8 @@ class CloudFunction
             return false;
         }
 
-        $cmd = 'gcloud -q '.self::GCLOUD_COMPONENT.' delete '
-            .$this->functionName.' --project '.$this->project.' --region '.$this->region;
+        $cmd = 'gcloud -q ' . self::GCLOUD_COMPONENT . ' delete '
+            . $this->functionName . ' --project ' . $this->project . ' --region ' . $this->region;
         $ret = $this->execWithRetry($cmd, $retries);
         if ($ret) {
             $this->deployed = false;
@@ -217,7 +218,7 @@ class CloudFunction
             return false;
         }
 
-        return 'http://localhost:'.$this->port;
+        return 'http://localhost:' . $this->port;
     }
 
     /**
@@ -229,7 +230,7 @@ class CloudFunction
     public function getBaseUrl($retries = 3)
     {
         if (!$this->deployed) {
-            echo '$this->deployed is empty by the time getBaseUrl is called.'.PHP_EOL;
+            echo '$this->deployed is empty by the time getBaseUrl is called.' . PHP_EOL;
             $this->errorLog('The function has not been deployed.');
 
             return false;
@@ -242,8 +243,8 @@ class CloudFunction
         }
 
         if (empty($this->url)) {
-            $cmd = 'gcloud -q '.self::GCLOUD_COMPONENT.' describe '.$this->functionName
-            .' --format \'value(httpsTrigger.url)\' --project '.$this->project.' --region '.$this->region;
+            $cmd = 'gcloud -q ' . self::GCLOUD_COMPONENT . ' describe ' . $this->functionName
+            . ' --format \'value(httpsTrigger.url)\' --project ' . $this->project . ' --region ' . $this->region;
             $this->url = $this->execWithRetry($cmd, $retries, $url);
             $this->url = $url[0];
         }

--- a/src/TestUtils/GcloudWrapper/CloudRun.php
+++ b/src/TestUtils/GcloudWrapper/CloudRun.php
@@ -85,7 +85,7 @@ class CloudRun
 
         $orgDir = getcwd();
         if (chdir($this->dir) === false) {
-            $this->errorLog('Can not chdir to '.$this->dir);
+            $this->errorLog('Can not chdir to ' . $this->dir);
 
             return false;
         }
@@ -118,11 +118,12 @@ class CloudRun
         }
         $orgDir = getcwd();
         if (chdir($this->dir) === false) {
-            $this->errorLog('Can not chdir to '.$this->dir);
+            $this->errorLog('Can not chdir to ' . $this->dir);
 
             return false;
         }
-        $cmd = sprintf('gcloud beta %s deploy %s --image %s%s --platform %s --project %s',
+        $cmd = sprintf(
+            'gcloud beta %s deploy %s --image %s%s --platform %s --project %s',
             self::GCLOUD_COMPONENT,
             $this->service,
             $image,
@@ -153,7 +154,8 @@ class CloudRun
         $options = array_merge([
             'retries' => 3,
         ], $options);
-        $cmd = sprintf('gcloud beta %s services delete %s%s --platform %s --project %s',
+        $cmd = sprintf(
+            'gcloud beta %s services delete %s%s --platform %s --project %s',
             self::GCLOUD_COMPONENT,
             $this->service,
             $this->region ? sprintf(' --region %s', $this->region) : '',
@@ -182,7 +184,8 @@ class CloudRun
         $options = array_merge([
             'retries' => 3,
         ], $options);
-        $cmd = sprintf('gcloud container images delete %s --project %s',
+        $cmd = sprintf(
+            'gcloud container images delete %s --project %s',
             $image,
             $this->project
         );
@@ -208,7 +211,8 @@ class CloudRun
         if ($this->url) {
             return $this->url;
         }
-        $cmd = sprintf('gcloud beta %s services describe %s%s --platform %s --project %s',
+        $cmd = sprintf(
+            'gcloud beta %s services describe %s%s --platform %s --project %s',
             self::GCLOUD_COMPONENT,
             $this->service,
             $this->region ? sprintf(' --region %s', $this->region) : '',

--- a/src/TestUtils/GcloudWrapper/CloudRun.php
+++ b/src/TestUtils/GcloudWrapper/CloudRun.php
@@ -18,10 +18,7 @@
 namespace Google\Cloud\TestUtils\GcloudWrapper;
 
 /**
- * Class GcloudWrapper
- * @package Google\Cloud\TestUtils
- *
- * A class representing App Engine application.
+ * Class GcloudWrapper.
  */
 class CloudRun
 {
@@ -42,18 +39,15 @@ class CloudRun
     /** @var string */
     private $url;
 
-    const GCLOUD_RUN = 'run';
+    const GCLOUD_COMPONENT = 'run';
     const DEFAULT_SERVICE = 'default';
     const DEFAULT_REGION = 'us-central1';
     const DEFAULT_PLATFORM = 'managed';
 
     /**
-     * Constructor of GcloudWrapper.
+     * Constructor of CloudRun.
      *
      * @param string $project
-     * @param string $version
-     * @param string|null $dir optional
-     * @param int $port optional
      */
     public function __construct($project, array $options = [])
     {
@@ -76,10 +70,11 @@ class CloudRun
     /**
      * Deploy the app to the Google Cloud Platform using Cloud Run.
      *
-     * @param string $image The container image to deploy
-     * @param array $options List of options
-     *      $retries int Number of retries upon failure.
-     * @return bool true if deployment suceeds, false upon failure.
+     * @param string $image   The container image to deploy
+     * @param array  $options list of options
+     *                        $retries int Number of retries upon failure
+     *
+     * @return bool true if deployment suceeds, false upon failure
      */
     public function build($image, array $options = [])
     {
@@ -90,22 +85,25 @@ class CloudRun
 
         $orgDir = getcwd();
         if (chdir($this->dir) === false) {
-            $this->errorLog('Can not chdir to ' . $this->dir);
+            $this->errorLog('Can not chdir to '.$this->dir);
+
             return false;
         }
         $cmd = sprintf('gcloud builds submit --tag %s', $image);
         $ret = $this->execWithRetry($cmd, $options['retries']);
         chdir($orgDir);
+
         return $ret;
     }
 
     /**
      * Deploy the app to the Google Cloud Platform using Cloud Run.
      *
-     * @param string $image The container image to deploy
-     * @param array $options List of options
-     *      $retries int Number of retries upon failure.
-     * @return bool true if deployment suceeds, false upon failure.
+     * @param string $image   The container image to deploy
+     * @param array  $options list of options
+     *                        $retries int Number of retries upon failure
+     *
+     * @return bool true if deployment suceeds, false upon failure
      */
     public function deploy($image, array $options = [])
     {
@@ -115,15 +113,17 @@ class CloudRun
         ], $options);
         if ($this->deployed) {
             $this->errorLog('The app has been already deployed.');
+
             return false;
         }
         $orgDir = getcwd();
         if (chdir($this->dir) === false) {
-            $this->errorLog('Can not chdir to ' . $this->dir);
+            $this->errorLog('Can not chdir to '.$this->dir);
+
             return false;
         }
         $cmd = sprintf('gcloud beta %s deploy %s --image %s%s --platform %s --project %s',
-            self::GCLOUD_RUN,
+            self::GCLOUD_COMPONENT,
             $this->service,
             $image,
             $this->region ? sprintf(' --region %s', $this->region) : '',
@@ -135,14 +135,16 @@ class CloudRun
         if ($ret) {
             $this->deployed = true;
         }
+
         return $ret;
     }
 
     /**
      * Delete the deployed app.
      *
-     * @param array $options List of options
-     *      $retries int Number of retries upon failure.
+     * @param array $options list of options
+     *                       $retries int Number of retries upon failure
+     *
      * @return bool true if the app is succesfully deleted, otherwise false
      */
     public function delete($options = [])
@@ -152,7 +154,7 @@ class CloudRun
             'retries' => 3,
         ], $options);
         $cmd = sprintf('gcloud beta %s services delete %s%s --platform %s --project %s',
-            self::GCLOUD_RUN,
+            self::GCLOUD_COMPONENT,
             $this->service,
             $this->region ? sprintf(' --region %s', $this->region) : '',
             $this->platform,
@@ -162,14 +164,16 @@ class CloudRun
         if ($ret) {
             $this->deployed = false;
         }
+
         return $ret;
     }
 
     /**
      * Delete the deployed app.
      *
-     * @param array $options List of options
-     *      $retries int Number of retries upon failure.
+     * @param array $options list of options
+     *                       $retries int Number of retries upon failure
+     *
      * @return bool true if the app is succesfully deleted, otherwise false
      */
     public function deleteImage($image, array $options = [])
@@ -182,6 +186,7 @@ class CloudRun
             $image,
             $this->project
         );
+
         return $this->execWithRetry($cmd, $options['retries']);
     }
 
@@ -189,19 +194,22 @@ class CloudRun
      * Return the base URL of the deployed app.
      *
      * @param string $service optional
+     *
      * @return mixed returns the base URL of the deployed app, or false when
-     *     the app is not deployed.
+     *               the app is not deployed
      */
     public function getBaseUrl($service = 'default')
     {
         if (!$this->deployed) {
             $this->errorLog('The app has not been deployed.');
+
+            return false;
         }
         if ($this->url) {
             return $this->url;
         }
         $cmd = sprintf('gcloud beta %s services describe %s%s --platform %s --project %s',
-            self::GCLOUD_RUN,
+            self::GCLOUD_COMPONENT,
             $this->service,
             $this->region ? sprintf(' --region %s', $this->region) : '',
             $this->platform,
@@ -209,6 +217,7 @@ class CloudRun
         );
         $cmd .= '| grep -m1 -oh "https:\/\/.*\.run\.app$"';
         $this->execWithRetry($cmd, 0, $output);
+
         return $this->url = $output[0];
     }
 }

--- a/src/TestUtils/GcloudWrapper/CloudRun.php
+++ b/src/TestUtils/GcloudWrapper/CloudRun.php
@@ -18,7 +18,7 @@
 namespace Google\Cloud\TestUtils\GcloudWrapper;
 
 /**
- * Class GcloudWrapper.
+ * Class CloudRun.
  */
 class CloudRun
 {

--- a/src/TestUtils/GcloudWrapper/GcloudWrapperTrait.php
+++ b/src/TestUtils/GcloudWrapper/GcloudWrapperTrait.php
@@ -60,7 +60,7 @@ trait GcloudWrapperTrait
 
     private function errorLog($message)
     {
-        fwrite(STDERR, $message."\n");
+        fwrite(STDERR, $message . "\n");
     }
 
     protected function execWithRetry($cmd, $retries = 3, &$output = null)
@@ -70,7 +70,7 @@ trait GcloudWrapperTrait
             if ($ret === 0) {
                 return true;
             } elseif ($i <= $retries) {
-                $this->errorLog('Retrying the command: '.$cmd);
+                $this->errorLog('Retrying the command: ' . $cmd);
             }
         }
 

--- a/src/TestUtils/GcloudWrapper/GcloudWrapperTrait.php
+++ b/src/TestUtils/GcloudWrapper/GcloudWrapperTrait.php
@@ -20,10 +20,7 @@ namespace Google\Cloud\TestUtils\GcloudWrapper;
 use Symfony\Component\Process\Process;
 
 /**
- * Trait GcloudWrapperTrait
- * @package Google\Cloud\TestUtils
- *
- * Traits for classes wrapping gcloud
+ * Trait GcloudWrapperTrait.
  */
 trait GcloudWrapperTrait
 {
@@ -43,10 +40,10 @@ trait GcloudWrapperTrait
     private $dir;
 
     /**
-     * Constructor of GcloudWrapper.
+     * Set trait properties to default values.
      *
-     * @param string $project
-     * @param string|null $dir optional
+     * @param string      $project
+     * @param string|null $dir     optional
      */
     private function setDefaultVars(
         $project,
@@ -63,19 +60,20 @@ trait GcloudWrapperTrait
 
     private function errorLog($message)
     {
-        fwrite(STDERR, $message . "\n");
+        fwrite(STDERR, $message."\n");
     }
 
     protected function execWithRetry($cmd, $retries = 3, &$output = null)
     {
-        for ($i = 0; $i <= $retries; $i++) {
+        for ($i = 0; $i <= $retries; ++$i) {
             exec($cmd, $output, $ret);
             if ($ret === 0) {
                 return true;
             } elseif ($i <= $retries) {
-                $this->errorLog('Retrying the command: ' . $cmd);
+                $this->errorLog('Retrying the command: '.$cmd);
             }
         }
+
         return false;
     }
 
@@ -94,6 +92,7 @@ trait GcloudWrapperTrait
      * Create \Symfony\Component\Process\Process with a given string.
      *
      * @param string $cmd
+     *
      * @return Process
      */
     protected function createProcess($cmd)
@@ -102,7 +101,7 @@ trait GcloudWrapperTrait
     }
 
     /**
-     * Stop the dev_appserver.
+     * Stop the process.
      */
     public function stop()
     {

--- a/src/TestUtils/GcloudWrapper/GcloudWrapperTrait.php
+++ b/src/TestUtils/GcloudWrapper/GcloudWrapperTrait.php
@@ -95,9 +95,9 @@ trait GcloudWrapperTrait
      *
      * @return Process
      */
-    protected function createProcess($cmd)
+    protected function createProcess($cmd, array $env = [])
     {
-        return new Process(explode(' ', $cmd));
+        return new Process(explode(' ', $cmd), null, $env);
     }
 
     /**


### PR DESCRIPTION
This is initial support for end-to-end testing support for Cloud Functions. It provides the expected lifecycle management to deploy and delete the function.

* Creates `Google\Cloud\TestUtils\GcloudWrapper\CloudFunction.php` to provide capability.
* Creates `Google\Cloud\TestUtils\CloudFunctionDeploymentTrait.php` to provide default implementation.
* Imposes some code style standards on other files in `Google\Cloud\TestUtils\GcloudWrapper`, along with a few comment corrections.

## Usage Example

```php
<?php
namespace Google\Cloud\Samples\Functions\Helloworld;

use Google\Cloud\TestUtils\CloudFunctionDeploymentTrait;
use Google\Cloud\TestUtils\EventuallyConsistentTestTrait;
use PHPUnit\Framework\TestCase;

/**
 * Class DeployTest.
 */
class DeployTest extends TestCase
{
    use CloudFunctionDeploymentTrait;
    use EventuallyConsistentTestTrait;

    private static $name = 'helloHttp';

    public function testFunction()
    {
        // Run the test.
        $resp = $this->client->get('/'.self::$name);

        // Assert status code.
        $this->assertEquals('200', $resp->getStatusCode());

        // Assert function output.
        $expected = trim('Hello, World!');
        $actual = trim((string) $resp->getBody());
        $this->assertEquals($expected, $actual);
    }
}
```

Across multiple local test runs, this test completed in **1.15 to 1.5 minutes** using **6 MB** memory.
