### PR TITLE
feat(functions): override arbitrary flags, run without deploy

### DIFF
--- a/src/TestUtils/GcloudWrapper/CloudFunction.php
+++ b/src/TestUtils/GcloudWrapper/CloudFunction.php
@@ -61,7 +61,7 @@ class CloudFunction
         $deployFlags = array_merge_recursive([
             '--runtime' => self::DEFAULT_RUNTIME,
             '--entry-point' => $entryPoint,
-        ], $options['deployFlags']);
+        ], $options['deployFlags'] ?? []);
         $options = array_merge([
             'functionName' => $entryPoint,
             'region' => self::DEFAULT_REGION,


### PR DESCRIPTION
Fixes #87 

This change allows appending deployment flags to a Cloud Function deploy.
It also fixes it so you can iteratively run deploy tests with `GOOGLE_KEEP_DEPLOYMENT` and `GOOGLE_SKIP_DEPLOYMENT` in order to test changes.

To append flags to the deploy command, simply add the following to your DeployTest.php:

```php
    protected static function deployFlags(array $flags = []) : array
    {
        $flags['--update-env-vars'] = 'FOO=BAR,TEST=EV';
        return $flags;
    }

```