### PR TITLE
chore(GCF test trait): don't throw on HTTP error

### DIFF
--- a/src/TestUtils/CloudFunctionLocalTestTrait.php
+++ b/src/TestUtils/CloudFunctionLocalTestTrait.php
@@ -55,7 +55,10 @@ trait CloudFunctionLocalTestTrait
     public function setUpClient()
     {
         $baseUrl = self::$fn->getLocalBaseUrl();
-        $this->client = new Client(['base_uri' => $baseUrl]);
+        $this->client = new Client([
+            'base_uri' => $baseUrl,
+            'http_errors' => false
+        ]);
     }
 
     /**


### PR DESCRIPTION
Ideally, we could make this an option instead of overriding default behavior.

(If it won't break any existing samples, such "optional" behavior may not be worth it.)