### PR TITLE
chore(functions): Allow HTTP errors in deployment tests

### DIFF
--- a/src/TestUtils/CloudFunctionDeploymentTrait.php
+++ b/src/TestUtils/CloudFunctionDeploymentTrait.php
@@ -113,6 +113,7 @@ trait CloudFunctionDeploymentTrait
             'handler' => $stack,
             'auth' => 'google_auth',
             'base_uri' => $targetAudience,
+            'http_errors' => false,
         ]);
     }
 


### PR DESCRIPTION
Missed a spot in #89