### PR TITLE
refactor(functions)!: rearrange CloudFunction support

### DIFF
--- a/src/TestUtils/CloudFunctionDeploymentTrait.php
+++ b/src/TestUtils/CloudFunctionDeploymentTrait.php
@@ -42,29 +42,33 @@ trait CloudFunctionDeploymentTrait
     {
         // If $fn is reinitialized, deployment state is reset.
         if (empty(self::$fn)) {
-            $props = self::initFunctionProperties([
-                'projectId' => self::requireEnv('GOOGLE_PROJECT_ID'),
-            ]);
-            self::$fn = CloudFunction::fromArray($props);
+            $props = [
+                'projectId' => self::requireEnv('GOOGLE_PROJECT_ID')
+            ];
+            if (isset(self::$entryPoint)) {
+                $props['entryPoint'] = self::$entryPoint;
+            }
+            if (isset(self::$functionSignatureType)) {
+                $props['functionSignatureType'] = self::$functionSignatureType;
+            }
+            self::$fn = CloudFunction::fromArray(
+                self::initFunctionProperties($props)
+            );
         }
     }
 
     /**
-     * Configure CloudFunction properties.
+     * Customize setUpFunction properties.
      *
-     * Example HTTP Function:
+     * Example:
      *
-     *     $props['entryPoint'] = 'helloHttp';
-     *     return $props;
-     *
-     * Example CloudEvent Function:
-     *
-     *     $props['entryPoint'] = 'helloEvent';
-     *     $props['functionSignatureType'] = 'cloudevent';
+     *     $props['dir'] = 'path/to/function-dir';
+     *     $props['region'] = 'us-west1';
      *     return $props;
      */
     private static function initFunctionProperties(array $props = [])
     {
+        return $props;
     }
 
     /**

--- a/src/TestUtils/CloudFunctionLocalTestTrait.php
+++ b/src/TestUtils/CloudFunctionLocalTestTrait.php
@@ -35,6 +35,9 @@ trait CloudFunctionLocalTestTrait
     /** @var \Google\Cloud\TestUtils\GcloudWrapper\CloudFunction */
     private static $fn;
 
+    /** @var \Symfony\Component\Process\Process; */
+    private static $localhost;
+
     /**
      * Start the function service.
      *
@@ -44,7 +47,7 @@ trait CloudFunctionLocalTestTrait
     {
         $projectId = self::requireEnv('GOOGLE_PROJECT_ID');
         self::$fn = new CloudFunction($projectId, self::$name);
-        self::$fn->run();
+        self::$localhost = self::$fn->run(self::$isCloudEventFunction ?? false);
     }
 
     /**

--- a/src/TestUtils/CloudFunctionLocalTestTrait.php
+++ b/src/TestUtils/CloudFunctionLocalTestTrait.php
@@ -45,9 +45,29 @@ trait CloudFunctionLocalTestTrait
      */
     public static function startFunction()
     {
-        $projectId = self::requireEnv('GOOGLE_PROJECT_ID');
-        self::$fn = new CloudFunction($projectId, self::$name);
-        self::$localhost = self::$fn->run(self::$isCloudEventFunction ?? false);
+        $props = self::initFunctionProperties([
+            'projectId' => self::requireEnv('GOOGLE_PROJECT_ID'),
+        ]);
+        self::$fn = CloudFunction::fromArray($props);
+        self::$localhost = self::$fn->run();
+    }
+
+    /**
+     * Configure CloudFunction properties.
+     *
+     * Example HTTP Function:
+     *
+     *     $props['entryPoint'] = 'helloHttp';
+     *     return $props;
+     *
+     * Example CloudEvent Function:
+     *
+     *     $props['entryPoint'] = 'helloEvent';
+     *     $props['functionSignatureType'] = 'cloudevent';
+     *     return $props;
+     */
+    private static function initFunctionProperties(array $props = [])
+    {
     }
 
     /**

--- a/src/TestUtils/CloudFunctionLocalTestTrait.php
+++ b/src/TestUtils/CloudFunctionLocalTestTrait.php
@@ -39,7 +39,7 @@ trait CloudFunctionLocalTestTrait
     private static $localhost;
 
     /**
-     * Start the function service.
+     * Prepare and start the function in a local development server.
      *
      * @beforeClass
      */
@@ -49,7 +49,19 @@ trait CloudFunctionLocalTestTrait
             'projectId' => self::requireEnv('GOOGLE_PROJECT_ID'),
         ]);
         self::$fn = CloudFunction::fromArray($props);
-        self::$localhost = self::$fn->run();
+        self::$localhost = self::doRun();
+    }
+
+    /**
+     * Start the development server based on the prepared function.
+     *
+     * Allows configuring server properties, for example:
+     *
+     *     return self::$fn->run(['FOO' => 'bar'], '9090', '/usr/local/bin/php');
+     */
+    private static function doRun()
+    {
+        return self::$fn->run();
     }
 
     /**

--- a/src/TestUtils/GcloudWrapper/CloudFunction.php
+++ b/src/TestUtils/GcloudWrapper/CloudFunction.php
@@ -103,11 +103,11 @@ class CloudFunction
             'region',
             'dir',
         ];
-    
+
         foreach ($argKeys as $key) {
             $args[] = $arr[$key] ?? '';
         }
-    
+
         return new static(...$args);
     }
 
@@ -192,7 +192,7 @@ class CloudFunction
 
             return false;
         }
-        
+
         try {
             $cmd = $this->gcloudCommand(['delete', $this->functionName]);
             $this->runWithRetry($cmd, $retries);
@@ -201,7 +201,7 @@ class CloudFunction
             $this->errorLog($e->getMessage());
             return false;
         }
-        
+
         return true;
     }
 

--- a/src/TestUtils/GcloudWrapper/CloudFunction.php
+++ b/src/TestUtils/GcloudWrapper/CloudFunction.php
@@ -265,20 +265,23 @@ class CloudFunction
     /**
      * Run the function with the php development server.
      *
+     * @param array $env environment variables in the form "[FOO] => bar"
+     * @param string $port override for local PHP server.
+     * @param string $phpBin override for PHP CLI path.
      * @return \Symfony\Component\Process\Process returns the php server process
      * @throws \Symfony\Component\Process\Exception\ProcessFailedException
      */
-    public function run(string $port = self::DEFAULT_PORT, string $phpBin = null)
+    public function run(array $env = [], string $port = self::DEFAULT_PORT, string $phpBin = null)
     {
         $this->localUri = 'localhost:' . $port;
 
         $phpBin = $phpBin ?? (new PhpExecutableFinder())->find();
         $cmd = $phpBin . ' -S ' . $this->localUri . ' vendor/bin/router.php';
 
-        $this->process = $this->createProcess($cmd, $this->dir, [
+        $this->process = $this->createProcess($cmd, $this->dir, array_merge($env, [
             'FUNCTION_TARGET' => $this->entryPoint,
             'FUNCTION_SIGNATURE_TYPE' => $this->functionSignatureType,
-        ]);
+        ]));
         $this->process->setTimeout(self::DEFAULT_TIMEOUT_SECONDS);
         $this->process->start();
 
@@ -301,7 +304,7 @@ class CloudFunction
      * @return \Symfony\Component\Process\Process returns the php server process
      * @throws \Symfony\Component\Process\Exception\ProcessFailedException
      */
-    public function runCloudEventFunction(string $port = '8080', string $phpBin = null)
+    public function runCloudEventFunction(string $port = self::DEFAULT_PORT, string $phpBin = null)
     {
         return $this->run(true, $port, $phpBin);
     }

--- a/src/TestUtils/GcloudWrapper/CloudFunction.php
+++ b/src/TestUtils/GcloudWrapper/CloudFunction.php
@@ -61,7 +61,7 @@ class CloudFunction
         $deployFlags = array_merge_recursive([
             '--runtime' => self::DEFAULT_RUNTIME,
             '--entry-point' => $entryPoint,
-        ], $options['deployFlags'] ?? []);
+        ], $options['deployFlags']);
         $options = array_merge([
             'functionName' => $entryPoint,
             'region' => self::DEFAULT_REGION,

--- a/src/TestUtils/GcloudWrapper/GcloudWrapperTrait.php
+++ b/src/TestUtils/GcloudWrapper/GcloudWrapperTrait.php
@@ -51,7 +51,7 @@ trait GcloudWrapperTrait
         $dir = null
     ) {
         $this->project = $project;
-        if ($dir === null) {
+        if (empty($dir)) {
             $dir = getcwd();
         }
         $this->deployed = false;


### PR DESCRIPTION
## Changes

Core things enabled in this change: Cleaner CloudEvent DeployTests and generally cleaner SystemTest options.

* 🚨  **Breaking Changes:** `private static $name` in tests no longer works.
* 🚨  **Breaking Changes:** `CloudFunctionDeploymentTrait::deployFlags()` from #88 is dropped.
* 🚨  **Breaking Changes:** `CloudFunction:__construct()` and various other methods take different parameters.
* ✅  **New Feature:** `CloudFunction::getFunctionName()` is a public method providing the name of the function. It handles GOOGLE_VERSION_ID for you. This is useful to enable logging tests.
* ✅  **New Feature:** `CloudFunction::run()` now returns the process object so system tests can retrieve output using the very useful helper methods in Symfony's process component.
* 🗂️  **Refactor**: Rearranged `CloudFunction.php` to move "local execution" methods towards the end.
* 🗂️  **Refactor**: Most options specific to `CloudFunction::deploy()` or `CloudFunction::run()` are now parameters to those methods.
* 🗂️  **Refactor**: Use of `exec()` is mostly replaced with the Symfony process component, and a new retry helper (`runWithRetry()`) is added to GcloudWrapperTrait to support that.
* 🗂️  **Refactor**: Internal helper `CloudFunction::gcloudCommand()` created for more consistent "gcloud functions" commands, this improves readability and makes the new parameters easier to work with.
* 🗂️  **Refactor**: Fewer methods return "value-or-false", instead we have value & optionally thrown exception. This is mostly to improve troubleshooting when developing in php-tools.

### Migration Path for HTTP Functions

1. Define the function in SystemTest and DeployTest like so:

```patch
-    private static $name = 'helloHttp';
+    private static function initFunctionProperties(array $props = [])
+    {
+        $props['entryPoint'] = 'helloHttp';
+        return $props;
+    }
```

2. If you were using deployFlags(), you can now add a method like this to your TestCase class:

```php
    /**
     * Deploy the Cloud Function, called from DeploymentTrait::deployApp().
     *
     * Overrides CloudFunctionDeploymentTrait::doDeploy().
     */
    private static function doDeploy()
    {
        self::$bucket = self::requireEnv('GOOGLE_STORAGE_BUCKET');
        return self::$fn->deploy([
            '--update-env-vars' => 'FOO=bar',
            '--trigger-bucket=' . self::$bucket,
        ]);
    }

```