### PR TITLE
chore(functions): decrease default retry count

### DIFF
--- a/src/TestUtils/CloudFunctionDeploymentTrait.php
+++ b/src/TestUtils/CloudFunctionDeploymentTrait.php
@@ -153,7 +153,7 @@ trait CloudFunctionDeploymentTrait
      * @param callable $process callback function to run on the logs.
      * @param int $retries the number of times to retry entry lookup
      */
-    private function processFunctionLogs(string $startTime, callable $process, int $retries = 10)
+    private function processFunctionLogs(string $startTime, callable $process, int $retries = 3)
     {
         if (empty(self::$loggingClient)) {
             self::$loggingClient = new LoggingClient([


### PR DESCRIPTION
#104 lets us specify retry counts, so let's lower the default value (and raise it in tests themselves where necessary)

_This should speed up our `functions` CI builds._