### PR TITLE
feat(test utils): support shell commands

### DIFF
--- a/src/TestUtils/ExecuteCommandTrait.php
+++ b/src/TestUtils/ExecuteCommandTrait.php
@@ -103,10 +103,10 @@ trait ExecuteCommandTrait
      */
     private static function createProcess($cmd, $timeout = false)
     {
-        if (!is_array($cmd)) {
-            $cmd = explode(' ', $cmd);
-        }
-        $process = new Process($cmd);
+        $process = is_array($cmd) ?
+            new Process($cmd) :
+            Process::fromShellCommandline($cmd);
+        
         if (self::$workingDirectory) {
             $process->setWorkingDirectory(self::$workingDirectory);
         }


### PR DESCRIPTION
"Shell command" functionality is used [here](https://github.com/GoogleCloudPlatform/php-docs-samples/blob/master/appengine/standard/symfony-framework/test/DeploySymfonyTrait.php#L35), but is currently **unsupported** by this package.

_(This PR adds that support.)_