### PR TITLE
fix: beforeClass ordering issue

### DIFF
--- a/src/TestUtils/AppEngineDeploymentTrait.php
+++ b/src/TestUtils/AppEngineDeploymentTrait.php
@@ -26,9 +26,7 @@ namespace Google\Cloud\TestUtils;
 trait AppEngineDeploymentTrait
 {
     use TestTrait;
-    use DeploymentTrait {
-        DeploymentTrait::deployApp as baseDeployApp;
-    }
+    use DeploymentTrait;
 
     /** @var \Google\Cloud\TestUtils\GcloudWrapper */
     private static $gcloudWrapper;
@@ -39,18 +37,14 @@ trait AppEngineDeploymentTrait
     }
 
     /**
-     * Deploy the application.
-     * Override DeploymentTrait::deployApp to ensure $gcloudWrapper exists.
-     *
-     * @beforeClass
+     * Create the gcloudWrapper class, which is needed for deployment
      */
-    public static function deployApp()
+    public static function setUpDeploy()
     {
         self::$gcloudWrapper = new GcloudWrapper(
             self::requireEnv('GOOGLE_PROJECT_ID'),
             getenv('GOOGLE_VERSION_ID') ?: null
         );
-        self::baseDeployApp();
     }
 
     /**

--- a/src/TestUtils/CloudFunctionDeploymentTrait.php
+++ b/src/TestUtils/CloudFunctionDeploymentTrait.php
@@ -42,10 +42,8 @@ trait CloudFunctionDeploymentTrait
 
     /**
      * Prepare the Cloud Function.
-     *
-     * @beforeClass
      */
-    public static function setUpFunction()
+    public static function setUpDeploy()
     {
         // Make sure projectId is initalized
         if (empty(self::$projectId)) {
@@ -81,17 +79,6 @@ trait CloudFunctionDeploymentTrait
     private static function initFunctionProperties(array $props = [])
     {
         return $props;
-    }
-
-    /**
-     * Prepare to deploy app, called from DeploymentTrait::deployApp().
-     */
-    private static function beforeDeploy()
-    {
-        // Ensure function is set up before depoyment is attempted.
-        if (empty(self::$fn)) {
-            self::setUpFunction();
-        }
     }
 
     /**

--- a/src/TestUtils/DeploymentTrait.php
+++ b/src/TestUtils/DeploymentTrait.php
@@ -31,8 +31,16 @@ trait DeploymentTrait
     private $client;
 
     /**
-     * Called before deploying the app. The concrete test class can override
+     * Called before "beforeDeploy. Traits which extend this trait can override
      * this.
+     */
+    private static function setUpDeploy()
+    {
+    }
+
+    /**
+     * Called before deploying the app. Concrete tests which use this trait
+     * can override this.
      */
     private static function beforeDeploy()
     {
@@ -64,7 +72,8 @@ trait DeploymentTrait
             );
         }
         if (getenv('GOOGLE_SKIP_DEPLOYMENT') !== 'true') {
-            static::beforeDeploy();
+            static::setUpDeploy();  // for traits extending this trait
+            static::beforeDeploy(); // for individual tests
             if (static::doDeploy() === false) {
                 self::fail('Deployment failed.');
             }

--- a/src/TestUtils/DeploymentTrait.php
+++ b/src/TestUtils/DeploymentTrait.php
@@ -31,7 +31,7 @@ trait DeploymentTrait
     private $client;
 
     /**
-     * Called before "beforeDeploy. Traits which extend this trait can override
+     * Called before beforeDeploy. Traits which extend this trait can override
      * this.
      */
     private static function setUpDeploy()


### PR DESCRIPTION
In phpunit 8.5 on PHP 8.0, the ordering of `@beforeClass` execution changed so that the override of `DeploymentTrait::beforeDeploy` in `AppEngineDeploymentTrait` happens _after_ the imported (and renamed) `DeploymentTrait::baseBeforeDeploy`. As a result, we get a fatal error on a null object.

The solution is to add a _new_ method in `DeploymentTrait` specifically for traits which extend it, called `setUpDeploy`, and allow the extending traits to use it. This will also preserve BC for existing tests which are using `beforeDeploy`, and free up `beforeDeploy` for use by any of the Cloud Functions deployment tests as well (it previously was being occupied by the trait)