### PR TITLE
fix: deploymenttrait execution order

### DIFF
--- a/src/TestUtils/AppEngineDeploymentTrait.php
+++ b/src/TestUtils/AppEngineDeploymentTrait.php
@@ -26,9 +26,7 @@ namespace Google\Cloud\TestUtils;
 trait AppEngineDeploymentTrait
 {
     use TestTrait;
-    use DeploymentTrait {
-        DeploymentTrait::deployApp as baseDeployApp;
-    }
+    use DeploymentTrait;
 
     /** @var \Google\Cloud\TestUtils\GcloudWrapper */
     private static $gcloudWrapper;
@@ -50,7 +48,7 @@ trait AppEngineDeploymentTrait
             self::requireEnv('GOOGLE_PROJECT_ID'),
             getenv('GOOGLE_VERSION_ID') ?: null
         );
-        self::baseDeployApp();
+        self::doDeployApp();
     }
 
     /**

--- a/src/TestUtils/DeploymentTrait.php
+++ b/src/TestUtils/DeploymentTrait.php
@@ -58,6 +58,11 @@ trait DeploymentTrait
      */
     public static function deployApp()
     {
+        self::doDeployApp();
+    }
+
+    private static function doDeployApp()
+    {
         if (getenv('RUN_DEPLOYMENT_TESTS') !== 'true') {
             self::markTestSkipped(
                 'To run this test, set RUN_DEPLOYMENT_TESTS env to true.'


### PR DESCRIPTION
Fixes error in Kokoro deployment tests from incorrect function execution order (due to function inheritance)

Tested locally and this seems to fix the issue