### PR TITLE
fix: opt to use functions framework router, if available

### DIFF
--- a/src/TestUtils/GcloudWrapper/CloudFunction.php
+++ b/src/TestUtils/GcloudWrapper/CloudFunction.php
@@ -263,7 +263,7 @@ class CloudFunction
     }
 
     /**
-     * Run the function with the php development server.
+     * Run the function with the Functions Framework router, or php development server.
      *
      * @param array $env environment variables in the form "[FOO] => bar"
      * @param string $port override for local PHP server.
@@ -276,7 +276,16 @@ class CloudFunction
         $this->localUri = 'localhost:' . $port;
 
         $phpBin = $phpBin ?? (new PhpExecutableFinder())->find();
-        $cmd = $phpBin . ' -S ' . $this->localUri . ' vendor/bin/router.php';
+
+        // Opt to use functions framework router, if available.
+        $ff_router = 'vendor/google/cloud-functions-framework/router.php';
+        $default_router = 'vendor/bin/router.php';
+
+        if (file_exists($ff_router)) {
+            $cmd = $phpBin . ' -S ' . $this->localUri . $ff_router;
+        } else {
+            $cmd = $phpBin . ' -S ' . $this->localUri . $default_router;
+        }
 
         $this->process = $this->createProcess($cmd, $this->dir, array_merge($env, [
             'FUNCTION_TARGET' => $this->entryPoint,

--- a/src/TestUtils/GcloudWrapper/CloudFunction.php
+++ b/src/TestUtils/GcloudWrapper/CloudFunction.php
@@ -263,7 +263,7 @@ class CloudFunction
     }
 
     /**
-     * Run the function with the Functions Framework router, or php development server.
+     * Run the function with the php development server.
      *
      * @param array $env environment variables in the form "[FOO] => bar"
      * @param string $port override for local PHP server.

--- a/src/TestUtils/GcloudWrapper/CloudFunction.php
+++ b/src/TestUtils/GcloudWrapper/CloudFunction.php
@@ -277,15 +277,8 @@ class CloudFunction
 
         $phpBin = $phpBin ?? (new PhpExecutableFinder())->find();
 
-        // Opt to use functions framework router, if available.
-        $ff_router = 'vendor/google/cloud-functions-framework/router.php';
-        $default_router = 'vendor/bin/router.php';
-
-        if (file_exists($ff_router)) {
-            $cmd = $phpBin . ' -S ' . $this->localUri . $ff_router;
-        } else {
-            $cmd = $phpBin . ' -S ' . $this->localUri . $default_router;
-        }
+        $router = 'vendor/google/cloud-functions-framework/router.php';
+        $cmd = sprintf('%s -S %s %s', $phpBin, $this->localUri, $router);
 
         $this->process = $this->createProcess($cmd, $this->dir, array_merge($env, [
             'FUNCTION_TARGET' => $this->entryPoint,


### PR DESCRIPTION
Updates the invocation of functions for local testing with the new suggested method for functions framework, if the alternative `router.php` file exists. 

https://github.com/GoogleCloudPlatform/functions-framework-php/pull/163


Should resolve build errors like https://github.com/GoogleCloudPlatform/php-docs-samples/pull/1936 where tests aren't succeeding for reasons unrelated to the sample code. 

(php not primary language, may not be most correct way to implementing this check.)