### PR TITLE
fix: use __CLASS__ instead of deprecated get_class()

### DIFF
--- a/src/TestUtils/TestTrait.php
+++ b/src/TestUtils/TestTrait.php
@@ -121,7 +121,7 @@ trait TestTrait
         $sampleFile = $sampleName;
         if ('/' !== $sampleName[0]) {
             // Default to 'src/' in sample directory
-            $reflector = new ReflectionClass(get_class());
+            $reflector = new ReflectionClass(__CLASS__);
             $testDir = dirname($reflector->getFileName());
             $sampleFile = sprintf('%s/../src/%s.php', $testDir, $sampleName);
         }


### PR DESCRIPTION
Calling get_class() without arguments is deprecated in `src/TestUtils/TestTrait.php`
