### PR TITLE
chore: use __CLASS__ instead of get_class

### DIFF
--- a/src/TestUtils/TestTrait.php
+++ b/src/TestUtils/TestTrait.php
@@ -124,7 +124,7 @@ trait TestTrait
         $sampleFile = $sampleName;
         if ('/' !== $sampleName[0]) {
             // Default to 'src/' in sample directory
-            $reflector = new ReflectionClass(get_class());
+            $reflector = new ReflectionClass(__CLASS__);
             $testDir = dirname($reflector->getFileName());
             $sampleFile = sprintf('%s/../src/%s.php', $testDir, $sampleName);
         }


### PR DESCRIPTION
this will prevent the following deprecation warning in PHP 8.3+

```
Deprecated: Calling get_class() without arguments is deprecated in vendor/google/cloud-tools/src/TestUtils/TestTrait.php on line 127
```