### PR TITLE
fix: expand symfony components to allow for php 8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,11 +15,11 @@
     "require": {
         "php": ">=8.0",
         "guzzlehttp/guzzle": "~7.0",
-        "symfony/browser-kit": "^5.4 || ^6.4 || ^7.0",
-        "symfony/console": "^5.4 || ^6.4 || ^7.0",
-        "symfony/filesystem": "^5.4 || ^6.4 || ^7.0",
-        "symfony/process": "^5.4 || ^6.4 || ^7.0",
-        "symfony/yaml": "^5.4 || ^6.4 || ^7.0",
+        "symfony/browser-kit": "^5.0 || ^6.4 || ^7.0",
+        "symfony/console": "^5.0 || ^6.4 || ^7.0",
+        "symfony/filesystem": "^5.0 || ^6.4 || ^7.0",
+        "symfony/process": "^5.0 || ^6.4 || ^7.0",
+        "symfony/yaml": "^5.0 || ^6.4 || ^7.0",
         "twig/twig": "~3.0"
     },
     "bin": [


### PR DESCRIPTION
currently `v0.16.0` (which contains important fixes) cannot be installed on PHP 8.0 because of composer conflicts. This should open it back up.